### PR TITLE
feat: consuming save questionnaire response endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.6.2",
         "date-fns": "^3.0.5",
         "react": "^18.2.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.48.2",
         "react-icons": "^4.12.0",
@@ -4600,6 +4601,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -5432,6 +5445,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.2",
     "date-fns": "^3.0.5",
     "react": "^18.2.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.48.2",
     "react-icons": "^4.12.0",

--- a/src/components/StepOne/StepOne.jsx
+++ b/src/components/StepOne/StepOne.jsx
@@ -7,54 +7,13 @@ import Button from '../../layouts/Button';
 import './StepOne.css';
 import useFormStore from '@/store/useFormStore';
 import useGetPoliticalOptions from '@/hooks/OptionsHook/useGetPoliticalOptions';
-import { useState, useEffect } from 'react';
-import { osName } from 'react-device-detect';
-import { ResponseService } from '@/services/response.service';
 
 const StepOne = ({ handleStep }) => {
-  const [ip, setIp] = useState();
-  const [responseCreated, setResponseCreated] = useState(false);
-  const idResponse = useFormStore(state => state.responseId);
-  const setIdResponse = useFormStore(state => state.setResponseId);
-
   const {
     control,
     handleSubmit,
     formState: { errors },
   } = useForm();
-
-  useEffect(() => {
-    const getIp = async () => {
-      try {
-        const response = await fetch('https://ipapi.co/json/');
-        const data = await response.json();
-        setIp(data);
-      } catch (error) {
-        console.error('Error fetching IP:', error);
-      }
-    };
-    getIp();
-  }, []);
-
-  useEffect(() => {
-    if (ip && !responseCreated && !idResponse) {
-      ResponseService.createResponse({
-        os: osName,
-        country: ip.country_name,
-        region: ip.region,
-        city: ip.city,
-        finishedSocialForm: false,
-        duration: 0,
-      })
-        .then(responseData => {
-          setResponseCreated(true);
-          setIdResponse(responseData);
-        })
-        .catch(error => {
-          console.error('Error creating response:', error);
-        });
-    }
-  }, [ip, osName, responseCreated, idResponse]);
 
   const { data: politicalOptions } = useGetPoliticalOptions();
   const setPoliticalCharacterization = useFormStore(state => state.setPoliticalCharacterization);

--- a/src/components/StepOne/StepOne.jsx
+++ b/src/components/StepOne/StepOne.jsx
@@ -7,18 +7,57 @@ import Button from '../../layouts/Button';
 import './StepOne.css';
 import useFormStore from '@/store/useFormStore';
 import useGetPoliticalOptions from '@/hooks/OptionsHook/useGetPoliticalOptions';
+import { useState, useEffect } from 'react';
+import { osName } from 'react-device-detect';
+import { ResponseService } from '@/services/response.service';
 
 const StepOne = ({ handleStep }) => {
+  const [ip, setIp] = useState();
+  const [responseCreated, setResponseCreated] = useState(false);
+  const idResponse = useFormStore(state => state.responseId);
+  const setIdResponse = useFormStore(state => state.setResponseId);
+
   const {
     control,
     handleSubmit,
     formState: { errors },
   } = useForm();
 
+  useEffect(() => {
+    const getIp = async () => {
+      try {
+        const response = await fetch('https://ipapi.co/json/');
+        const data = await response.json();
+        setIp(data);
+      } catch (error) {
+        console.error('Error fetching IP:', error);
+      }
+    };
+    getIp();
+  }, []);
+
+  useEffect(() => {
+    if (ip && !responseCreated && !idResponse) {
+      ResponseService.createResponse({
+        os: osName,
+        country: ip.country_name,
+        region: ip.region,
+        city: ip.city,
+        finishedSocialForm: false,
+        duration: 0,
+      })
+        .then(responseData => {
+          setResponseCreated(true);
+          setIdResponse(responseData);
+        })
+        .catch(error => {
+          console.error('Error creating response:', error);
+        });
+    }
+  }, [ip, osName, responseCreated, idResponse]);
+
   const { data: politicalOptions } = useGetPoliticalOptions();
-
   const setPoliticalCharacterization = useFormStore(state => state.setPoliticalCharacterization);
-
   const onSubmit = data => {
     setPoliticalCharacterization(data.politicalCharacterization);
     handleStep();

--- a/src/hooks/useCreateResponse.jsx
+++ b/src/hooks/useCreateResponse.jsx
@@ -1,0 +1,22 @@
+import { ResponseService } from '@/services/response.service';
+import { toast } from 'sonner';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import useFormStore from '@/store/useFormStore';
+
+const useCreateResponse = () => {
+  const setIdResponse = useFormStore(state => state.setResponseId);
+  const navigate = useNavigate();
+
+  return useMutation(ResponseService.createResponse, {
+    onSuccess: data => {
+      setIdResponse(data);
+      navigate('/cuestionario');
+    },
+    onError: error => {
+      toast.error(error?.message || 'Ha ocurrido un error, intente nuevamente');
+    },
+  });
+};
+
+export default useCreateResponse;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,23 +1,46 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Toaster, toast } from 'sonner';
-
 import Button from '../../layouts/Button';
 import Terms from '@/components/Terms/Terms';
 import useFormStore from '@/store/useFormStore';
-import { useNavigate } from 'react-router-dom';
+import useCreateResponse from '@/hooks/useCreateResponse';
+import { osName } from 'react-device-detect';
 
 export default function Home() {
   const clearForm = useFormStore(state => state.clearForm);
   const [isChecked, setIsChecked] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const navigate = useNavigate();
   const setAcceptedTerms = useFormStore(state => state.setAcceptedTerms);
+  const { mutate: createResponse } = useCreateResponse();
+  const [ip, setIp] = useState();
+  const [isIpLoaded, setIsIpLoaded] = useState(false);
+
+  useEffect(() => {
+    const getIp = async () => {
+      try {
+        const response = await fetch('https://ipapi.co/json/');
+        const data = await response.json();
+        setIp(data);
+        setIsIpLoaded(true);
+      } catch (error) {
+        console.error('Error fetching IP:', error);
+      }
+    };
+    getIp();
+  }, []);
 
   const handleClick = () => {
     if (isChecked) {
       clearForm();
       setAcceptedTerms(true);
-      navigate('/cuestionario');
+      createResponse({
+        os: osName,
+        country: ip.country_name,
+        region: ip.region,
+        city: ip.city,
+        finishedSocialForm: false,
+        duration: 0,
+      });
     } else {
       toast.error('Por favor, acepte los términos y condiciones');
     }
@@ -79,7 +102,7 @@ export default function Home() {
               </span>
             </p>
             <div className="lg:pb-0 pb-10">
-              <Button title={'¡Quiero participar! '} onClick={handleClick} />
+              <Button title={'¡Quiero participar! '} onClick={handleClick} disabled={!isIpLoaded} />
             </div>
           </div>
         </div>

--- a/src/services/response.service.js
+++ b/src/services/response.service.js
@@ -1,0 +1,17 @@
+import api from './api.services';
+
+export class ResponseService {
+
+static async createResponse(surveyResponses) {
+    try {
+     
+      const { data, status } = await api.post('/surveyresponse/', surveyResponses)
+      if (status === 201) {     
+        return data.id
+      }
+    } catch (error) {
+      throw new Error('Error al obtener informacion');
+    }
+  }
+
+}

--- a/src/store/useFormStore.js
+++ b/src/store/useFormStore.js
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware';
 const useFormStore = create(
   persist(
   set => ({
+    responseId: null,
     acceptedTerms: null,
     politicalCharacterization: null,
     currentSurveySection: 0,
@@ -13,6 +14,11 @@ const useFormStore = create(
     oppositePoliticalResult: [],
     oppositeSocialResult: [],
     socialCharacterization:[],
+    setResponseId: responseId => {
+      set(state => {
+        return { ...state, responseId };
+      });
+    },
     setSocialCharacterization: socialCharacterization => {
       set(state => {
         return { ...state, socialCharacterization };
@@ -121,6 +127,7 @@ const useFormStore = create(
         socialResult: null,
         oppositePoliticalResult: [],
         oppositeSocialResult: [],
+        responseId: null,
       }));
     },
   }),


### PR DESCRIPTION
Tengo mis dudas sobre esto dado que a pesar de que funciona, se guarda en la db, te devuelve la id y se guarda en la store, ¿quizas existe una mejor forma de realizarlo?. 

El siguiente hook no esta en el PR.

![image](https://github.com/dlab-team/c14-frontend/assets/42621164/e5b95687-4dc5-4deb-a900-d6005a236b00)

Habia realizado este hook, pero me daba problemas dado que solo debia ser llamado cuando ip tuviese los datos desde la api de [ipapi.co](https://ipapi.co/json). Y honestamente no se me ocurrio como poder utilizar este hook sin romper las reglas que tienen sobre no llamarse dentro de una condicional o que no este en el nivel top de mi componente.

Cuando deje el hook de lado y me comunique directamente con el servicio, alli todo funciono correctamente dado que debo esperar a que tenga los datos de la ip, luego esperar la respuesta del endpoint nuestro para obtener la id y finalmente guardar la id para el futuro update/put con el finishDate y finishedSocialForm.

Pero de que funciona, funciona.

Ah, y este pr asume el fix que el Nico va a subir para el modelo de survey_response que se converso en el discord.